### PR TITLE
Add AnnotationGuideline model

### DIFF
--- a/app/models/annotation_guideline.rb
+++ b/app/models/annotation_guideline.rb
@@ -1,3 +1,5 @@
 class AnnotationGuideline < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: :true, length: { maximum: 255 }
 end

--- a/app/models/annotation_guideline.rb
+++ b/app/models/annotation_guideline.rb
@@ -1,0 +1,3 @@
+class AnnotationGuideline < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :annotation_guidelines
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :annotation_guidelines
+  has_many :annotation_guidelines, dependent: :destroy
 end

--- a/db/migrate/20250213072025_create_annotation_guidelines.rb
+++ b/db/migrate/20250213072025_create_annotation_guidelines.rb
@@ -1,0 +1,11 @@
+class CreateAnnotationGuidelines < ActiveRecord::Migration[8.0]
+  def change
+    create_table :annotation_guidelines do |t|
+      t.string :title, null: false
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_13_054606) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_13_072025) do
+  create_table "annotation_guidelines", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_annotation_guidelines_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -22,4 +31,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_13_054606) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "annotation_guidelines", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,24 @@
-User.create!(email: 'user1@example.com', password: 'password')
+user = User.create!(email: 'user1@example.com', password: 'password')
+
+10.times do |i|
+  AnnotationGuideline.create!(
+    user_id: user.id,
+    title: "Guideline#{i + 1}",
+    body: <<~MD
+      # Guideline#{i + 1}
+
+      ## Summary
+      Guideline#{i + 1} description. Annotate according to this guideline.
+
+      ## Rules
+      - **Rule1**: ・・・・・
+      - **Rule2**: ・・・・・
+      - **Rule3**: ・・・・・
+
+      ## Example
+      ```
+      curl -X POST /annotation.json
+      ```
+    MD
+  )
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,7 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-# one: {}
-# column: value
-#
-# two: {}
-# column: value
+one:
+  id: 1
+  email: test1@example.com
+  encrypted_password: password

--- a/test/models/annotation_guideline_test.rb
+++ b/test/models/annotation_guideline_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class AnnotationGuidelineTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
+  test "valid annotation guideline should be saved" do
+    assert_difference "AnnotationGuideline.count", 1 do
+      AnnotationGuideline.create(
+        title: "Guideline1",
+        body: "# Guideline 1",
+        user_id: @user.id
+      )
+    end
+  end
+
+  test "without title should not be saved" do
+    annotation_guideline = AnnotationGuideline.new(
+      title: nil,
+      body: "# Guideline without title",
+      user_id: @user.id
+    )
+
+    assert annotation_guideline.invalid?
+  end
+
+  test "title exceeding 255 chararcters should not be saved" do
+    long_title = "a" * 256
+    annotation_guideline = AnnotationGuideline.new(
+      title: long_title,
+      body: "# Guideline with a long title",
+      user_id: @user.id
+    )
+
+    assert annotation_guideline.invalid?
+  end
+end


### PR DESCRIPTION
Closes: #3

## 概要
AnnotationGuidelineモデルを作成しました。

## 作業内容
- AnnotationGuidelineモデルの作成
- Userモデルとの関連を設定
- seedの用意
- バリデーションの追加
  - titleのlength maximum 255はDBのエラーを出さないために設定しました。
- テストの追加