### PR TITLE
Add index page for annotation guideline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "devise"
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.10.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     logger (1.6.5)
     loofah (2.24.0)
@@ -331,6 +343,7 @@ DEPENDENCIES
   devise
   importmap-rails
   jbuilder
+  kaminari
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.1)

--- a/app/assets/stylesheets/annotation_guidelines.css
+++ b/app/assets/stylesheets/annotation_guidelines.css
@@ -1,0 +1,24 @@
+.pagination {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.pagination a {
+  padding: 8px 12px;
+  margin: 0 5px;
+  border: 1px solid #ddd;
+  color: #333;
+  text-decoration: none;
+}
+
+.pagination a:hover {
+  background-color: #ddd;
+}
+
+.pagination .current {
+  padding: 8px 12px;
+  margin: 0 5px;
+  background-color: #007bff;
+  color: white;
+  border-radius: 4px;
+}

--- a/app/assets/stylesheets/annotation_guidelines.css
+++ b/app/assets/stylesheets/annotation_guidelines.css
@@ -1,3 +1,10 @@
+.guideline-body {
+  max-width: 300px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .pagination {
   margin-top: 20px;
   text-align: center;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,20 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 10px;
+  text-align: center;
+}
+
+th {
+  background-color: #f4f4f4;
+  font-weight: bold;
+}

--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -1,4 +1,5 @@
 class AnnotationGuidelinesController < ApplicationController
   def index
+    @annotation_guidelines = AnnotationGuideline.includes(:user).order(updated_at: :desc)
   end
 end

--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -1,5 +1,7 @@
 class AnnotationGuidelinesController < ApplicationController
   def index
-    @annotation_guidelines = AnnotationGuideline.includes(:user).order(updated_at: :desc)
+    @annotation_guidelines = AnnotationGuideline.includes(:user)
+                                                .order(updated_at: :desc)
+                                                .page(params[:page])
   end
 end

--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -1,0 +1,4 @@
+class AnnotationGuidelinesController < ApplicationController
+  def index
+  end
+end

--- a/app/views/annotation_guidelines/index.html.erb
+++ b/app/views/annotation_guidelines/index.html.erb
@@ -20,3 +20,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate @annotation_guidelines %>

--- a/app/views/annotation_guidelines/index.html.erb
+++ b/app/views/annotation_guidelines/index.html.erb
@@ -13,7 +13,7 @@
     <% @annotation_guidelines.each do |guideline| %>
       <tr>
         <td><%= guideline.title %></td>
-        <td><%= guideline.body %></td>
+        <td class="guideline-body"><%= guideline.body %></td>
         <td><%= guideline.updated_at %></td>
         <td><%= guideline.user.email %></td>
       </tr>

--- a/app/views/annotation_guidelines/index.html.erb
+++ b/app/views/annotation_guidelines/index.html.erb
@@ -1,0 +1,22 @@
+<h1>AnnotationGuidelines</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Content</th>
+      <th>Updated at</th>
+      <th>Author</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @annotation_guidelines.each do |guideline| %>
+      <tr>
+        <td><%= guideline.title %></td>
+        <td><%= guideline.body %></td>
+        <td><%= guideline.updated_at %></td>
+        <td><%= guideline.user.email %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "annotation_guidelines#index"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 user = User.create!(email: 'user1@example.com', password: 'password')
 
-10.times do |i|
+30.times do |i|
   AnnotationGuideline.create!(
     user_id: user.id,
     title: "Guideline#{i + 1}",


### PR DESCRIPTION
Closes: #4

## 概要
AnnotationGuidelines一覧ページを作成しました。

## 実装内容
- AnnotationGuideline一覧ページ
- 最低限のスタイル当て
- ページネーション

## 動作確認
### 一覧画面
|<img width="1432" alt="image" src="https://github.com/user-attachments/assets/b50b4e2a-3cae-4470-930d-400f6a26ffc6" />|
|:-|

### ページネーション
|<img width="1433" alt="image" src="https://github.com/user-attachments/assets/98da9f99-ee15-48ca-845a-2e2442093ee6" />|
|:-|