### PR TITLE
Add annotation guideline edit function

### DIFF
--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -23,6 +23,20 @@ class AnnotationGuidelinesController < ApplicationController
     end
   end
 
+  def edit
+    @annotation_guideline = current_user.annotation_guidelines.find(params[:id])
+  end
+
+  def update
+    @annotation_guideline = current_user.annotation_guidelines.find(params[:id])
+
+    if @annotation_guideline.update(annotation_guideline_params)
+      redirect_to annotation_guideline_path(@annotation_guideline), notice: "Annotation Guideline was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def annotation_guideline_params

--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -1,4 +1,6 @@
 class AnnotationGuidelinesController < ApplicationController
+  before_action :set_annotation_guideline, only: %i[edit update]
+
   def index
     @annotation_guidelines = AnnotationGuideline.includes(:user)
                                                 .order(updated_at: :desc)
@@ -23,13 +25,9 @@ class AnnotationGuidelinesController < ApplicationController
     end
   end
 
-  def edit
-    @annotation_guideline = current_user.annotation_guidelines.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @annotation_guideline = current_user.annotation_guidelines.find(params[:id])
-
     if @annotation_guideline.update(annotation_guideline_params)
       redirect_to annotation_guideline_path(@annotation_guideline), notice: "Annotation Guideline was successfully updated."
     else
@@ -38,6 +36,10 @@ class AnnotationGuidelinesController < ApplicationController
   end
 
   private
+
+  def set_annotation_guideline
+    @annotation_guideline = current_user.annotation_guidelines.find(params[:id])
+  end
 
   def annotation_guideline_params
     params.require(:annotation_guideline).permit(:title, :body)

--- a/app/views/annotation_guidelines/_form.html.erb
+++ b/app/views/annotation_guidelines/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: @annotation_guideline) do |f| %>
+  <% if @annotation_guideline.errors.any? %>
+    <div class="error-messages">
+      <h2><%= pluralize(@annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
+      <ul>
+        <% @annotation_guideline.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :body %>
+    <%= f.text_area :body, class: "annotation_guideline_textarea" %>
+  </div>
+
+  <div>
+    <%= f.submit action_name == "new" ? "Create" : "Update" %>
+  </div>
+<% end %>
+

--- a/app/views/annotation_guidelines/_form.html.erb
+++ b/app/views/annotation_guidelines/_form.html.erb
@@ -1,9 +1,9 @@
-<%= form_with(model: @annotation_guideline) do |f| %>
-  <% if @annotation_guideline.errors.any? %>
+<%= form_with(model: annotation_guideline) do |f| %>
+  <% if annotation_guideline.errors.any? %>
     <div class="error-messages">
-      <h2><%= pluralize(@annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
+      <h2><%= pluralize(annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
       <ul>
-        <% @annotation_guideline.errors.full_messages.each do |message| %>
+        <% annotation_guideline.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
       </ul>

--- a/app/views/annotation_guidelines/edit.html.erb
+++ b/app/views/annotation_guidelines/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit Guideline</h1>
 
-<%= render "form", locals: { annotation_guideline: @annotation_guideline } %>
+<%= render partial: "form", locals: { annotation_guideline: @annotation_guideline } %>

--- a/app/views/annotation_guidelines/edit.html.erb
+++ b/app/views/annotation_guidelines/edit.html.erb
@@ -1,27 +1,3 @@
 <h1>Edit Guideline</h1>
 
-<%= form_with(model: @annotation_guideline) do |f| %>
-  <% if @annotation_guideline.errors.any? %>
-    <div class="error-messages">
-      <h2><%= pluralize(@annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
-      <ul>
-        <% @annotation_guideline.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= f.label :title %>
-    <%= f.text_field :title %>
-  </div>
-
-  <div>
-    <%= f.label :body %>
-    <%= f.text_area :body, class: "annotation_guideline_textarea" %>
-  </div>
-
-  <div><%= f.submit 'Update' %></div>
-<% end %>
-
+<%= render "form", locals: { annotation_guideline: @annotation_guideline } %>

--- a/app/views/annotation_guidelines/edit.html.erb
+++ b/app/views/annotation_guidelines/edit.html.erb
@@ -1,0 +1,27 @@
+<h1>Edit Guideline</h1>
+
+<%= form_with(model: @annotation_guideline) do |f| %>
+  <% if @annotation_guideline.errors.any? %>
+    <div class="error-messages">
+      <h2><%= pluralize(@annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
+      <ul>
+        <% @annotation_guideline.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :body %>
+    <%= f.text_area :body, class: "annotation_guideline_textarea" %>
+  </div>
+
+  <div><%= f.submit 'Update' %></div>
+<% end %>
+

--- a/app/views/annotation_guidelines/new.html.erb
+++ b/app/views/annotation_guidelines/new.html.erb
@@ -1,3 +1,3 @@
 <h1>New Guideline</h1>
 
-<%= render "form", locals: { annotation_guideline: @annotation_guideline } %>
+<%= render partial: "form", locals: { annotation_guideline: @annotation_guideline } %>

--- a/app/views/annotation_guidelines/new.html.erb
+++ b/app/views/annotation_guidelines/new.html.erb
@@ -1,27 +1,3 @@
 <h1>New Guideline</h1>
 
-<%= form_with(model: @annotation_guideline) do |f| %>
-  <% if @annotation_guideline.errors.any? %>
-    <div class="error-messages">
-      <h2><%= pluralize(@annotation_guideline.errors.count, "error") %> prevented this form from being saved:</h2>
-      <ul>
-        <% @annotation_guideline.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= f.label :title %>
-    <%= f.text_field :title %>
-  </div>
-
-  <div>
-    <%= f.label :body %>
-    <%= f.text_area :body, class: "annotation_guideline_textarea" %>
-  </div>
-
-  <div><%= f.submit 'Create' %></div>
-<% end %>
-
+<%= render "form", locals: { annotation_guideline: @annotation_guideline } %>

--- a/app/views/annotation_guidelines/show.html.erb
+++ b/app/views/annotation_guidelines/show.html.erb
@@ -4,4 +4,5 @@
   <%= @annotation_guideline.html_body %>
 </div>
 
+<%= link_to 'Edit', edit_annotation_guideline_path(@annotation_guideline) %>
 <%= link_to 'Back', :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "annotation_guidelines#index"
 
-  resources :annotation_guidelines, only: %i[index new create show]
+  resources :annotation_guidelines, only: %i[index new create show edit update]
 end


### PR DESCRIPTION
Closes: #7

## 概要
Guideline編集機能を追加しました。

## 作業内容
- markdownエディタを使った編集ページの作成
- 詳細ページに編集ページへのリンクを配置
- リファクタリング
  - AnnotationGuidelinesControllerの重複部分の共通化
  - フォームのパーシャル化

## 動作確認
### 編集ページ
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/ddb936ef-f224-4584-a7e0-4692cbede991" />|
|:-|

### バリデーションエラー
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/04be1bab-5ea3-47a8-8ec4-d6974933f1ad" />|
|:-|

### 保存成功時
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/db38b9fe-1902-4d2f-9d11-dd9725abbe4c" />|
|:-|