### PR TITLE
Add function to delete annotation guideline

### DIFF
--- a/app/controllers/annotation_guidelines_controller.rb
+++ b/app/controllers/annotation_guidelines_controller.rb
@@ -1,5 +1,5 @@
 class AnnotationGuidelinesController < ApplicationController
-  before_action :set_annotation_guideline, only: %i[edit update]
+  before_action :set_annotation_guideline, only: %i[edit update destroy]
 
   def index
     @annotation_guidelines = AnnotationGuideline.includes(:user)
@@ -33,6 +33,11 @@ class AnnotationGuidelinesController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @annotation_guideline.destroy
+    redirect_to annotation_guidelines_path, notice: "Annotation Guideline was successfully deleted."
   end
 
   private

--- a/app/views/annotation_guidelines/show.html.erb
+++ b/app/views/annotation_guidelines/show.html.erb
@@ -5,4 +5,5 @@
 </div>
 
 <%= link_to 'Edit', edit_annotation_guideline_path(@annotation_guideline) %>
+<%= link_to 'Delete', @annotation_guideline, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
 <%= link_to 'Back', :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "annotation_guidelines#index"
 
-  resources :annotation_guidelines, only: %i[index new create show edit update]
+  resources :annotation_guidelines
 end


### PR DESCRIPTION
Closes: #17

## 概要
Guideline削除機能を追加しました。

## 作業内容
- Guideline詳細ページに削除リンクを設置
- 削除機能の追加

## 動作確認
### 削除時
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/1cae1efa-093c-43b2-a5e2-8ff718a28b8f" />|
|:-|

### 削除後
|<img width="800" alt="image" src="https://github.com/user-attachments/assets/5351ce83-a2e9-465e-84b6-c153cd35e0a7" />|
|:-|