### PR TITLE
Change note model specification

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,6 +1,7 @@
 class Note < ApplicationRecord
   belongs_to :user
 
+  before_create :set_id
   before_validation :set_default_title, if: -> { title.blank? && body.present? }
 
   validates :title, length: { maximum: 255 }
@@ -18,6 +19,10 @@ class Note < ApplicationRecord
   end
 
   private
+
+  def set_id
+    self.id = SecureRandom.uuid
+  end
 
   def set_default_title
     self.title = "no title"

--- a/db/migrate/20250219020426_recreate_notes.rb
+++ b/db/migrate/20250219020426_recreate_notes.rb
@@ -1,0 +1,18 @@
+class RecreateNotes < ActiveRecord::Migration[8.0]
+  def up
+    drop_table :notes, if_exists: true
+
+    create_table :notes, id: false do |t|
+      t.string :id, primary_key: true, null: false
+      t.string :title, null: false
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :notes, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_18_075402) do
-  create_table "notes", force: :cascade do |t|
+ActiveRecord::Schema[8.0].define(version: 2025_02_19_020426) do
+  create_table "notes", id: :string, force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
     t.integer "user_id", null: false

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -5,7 +5,7 @@ class NoteTest < ActiveSupport::TestCase
     @user = users(:one)
   end
 
-  test "valid note should be saved" do
+  test "should save when title and body present" do
     assert_difference "Note.count", 1 do
       Note.create(
         title: "Note1",
@@ -15,14 +15,44 @@ class NoteTest < ActiveSupport::TestCase
     end
   end
 
-  test "without title should not be saved" do
-    note = Note.new(
-      title: nil,
-      body: "# Note without title",
-      user_id: @user.id
-    )
+  test "should save when title present, body empty" do
+    assert_difference "Note.count", 1 do
+      Note.create(
+        title: "Note1",
+        body: "",
+        user_id: @user.id
+      )
+    end
+  end
 
-    assert note.invalid?
+  test "should save when title empty, body present" do
+    assert_difference "Note.count", 1 do
+      Note.create(
+        title: "",
+        body: "# Note 1",
+        user_id: @user.id
+      )
+    end
+  end
+
+  test "should not save when title and body both empty" do
+    assert_difference "Note.count", 0 do
+      Note.create(
+        title: "",
+        body: "",
+        user_id: @user.id
+      )
+    end
+  end
+
+  test "should set default title when title empty" do
+    note = Note.create(
+            title: "",
+            body: "# Note 1",
+            user_id: @user.id
+          )
+
+    assert_equal "no title", note.title
   end
 
   test "title exceeding 255 chararcters should not be saved" do


### PR DESCRIPTION
## 概要
Noteモデルのパスやバリデーションの仕様変更を行いました。

## 作業内容
- バリデーションの変更
  - title, bodyが空の場合はエラー
  - bodyのみある場合はデフォルトのtitleをセット
- モデルテストの修正
- Noteのパスをnotes/:uuidにするため、idの値をuuidに変更

## 動作確認
### title, bodyが空の場合にエラーが出る
```
annotation-guidelines(dev)> Note.create!(title: "", body: "", user_id: 1)
  TRANSACTION (0.1ms)  BEGIN immediate TRANSACTION /*application='AnnotationGuidelines'*/
  User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='AnnotationGuidelines'*/
  TRANSACTION (0.0ms)  ROLLBACK TRANSACTION /*application='AnnotationGuidelines'*/
(annotation-guidelines):1:in '<main>': Validation failed: Title and body cannot both be empty. (ActiveRecord::RecordInvalid)
```

### titleが空の場合にデフォルトのtitleがセットされる
```
annotation-guidelines(dev)> Note.create!(title: "", body: "abc", user_id: 1)
  TRANSACTION (0.3ms)  BEGIN immediate TRANSACTION /*application='AnnotationGuidelines'*/
  User Load (1.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='AnnotationGuidelines'*/
  Note Create (0.3ms)  INSERT INTO "notes" ("id", "title", "body", "user_id", "created_at", "updated_at") VALUES ('6547fdd3-ee8a-4bea-81b1-5aa1fc426a76', 'no title', 'abc', 1, '2025-02-19 02:36:36.337504', '2025-02-19 02:36:36.337504') RETURNING "id" /*application='AnnotationGuidelines'*/
  TRANSACTION (0.8ms)  COMMIT TRANSACTION /*application='AnnotationGuidelines'*/
=>
#<Note:0x0000000101354740
 id: "6547fdd3-ee8a-4bea-81b1-5aa1fc426a76",
 title: "no title",
 body: "abc",
 user_id: 1,
 created_at: "2025-02-19 02:36:36.337504000 +0000",
 updated_at: "2025-02-19 02:36:36.337504000 +0000">
```

### 詳細/編集ページのパスがuuidで表示されている
#### 詳細ページ
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/c736d214-7170-4af2-b139-d37effbb8ce1" />|
|:-|

#### 編集ページ
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/bc75c92a-e7cb-4e86-9200-1870776a7a05" />|
|:-|

その他、作成機能や削除機能も問題なく動作しました。