### PR TITLE
Change Note validation

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,7 +1,7 @@
 class Note < ApplicationRecord
   belongs_to :user
 
-  before_validation :set_default_title, if: -> { title.blank? && body.present? }
+  before_save :set_default_title, if: -> { title.blank? && body.present? }
 
   validates :title, length: { maximum: 255 }
   validate :title_and_body_cannot_both_empty

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,7 +1,7 @@
 class Note < ApplicationRecord
   belongs_to :user
 
-  before_save :set_default_title, if: -> { title.blank? && body.present? }
+  before_save :set_default_title
 
   validates :title, length: { maximum: 255 }
   validate :title_and_body_cannot_both_empty
@@ -20,7 +20,9 @@ class Note < ApplicationRecord
   private
 
   def set_default_title
-    self.title = "no title"
+    if title.blank? && body.present?
+      self.title = "no title"
+    end
   end
 
   def title_and_body_cannot_both_empty

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,7 +4,7 @@ class Note < ApplicationRecord
   before_save :set_default_title
 
   validates :title, length: { maximum: 255 }
-  validate :title_and_body_cannot_both_empty
+  validate :must_have_title_or_body
 
   # Commonmarker ensures that potentially dangerous tags like <script> are already sanitized.
   # However, Brakeman still raises a Cross-Site Scripting warning when the raw output of Commonmarker.to_html is used in views.
@@ -25,7 +25,7 @@ class Note < ApplicationRecord
     end
   end
 
-  def title_and_body_cannot_both_empty
+  def must_have_title_or_body
     if title.blank? && body.blank?
       errors.add(:base, "Title and body cannot both be empty.")
     end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -5,7 +5,7 @@ class NoteTest < ActiveSupport::TestCase
     @user = users(:one)
   end
 
-  test "valid note should be saved" do
+  test "should save when title and body present" do
     assert_difference "Note.count", 1 do
       Note.create(
         title: "Note1",
@@ -15,14 +15,44 @@ class NoteTest < ActiveSupport::TestCase
     end
   end
 
-  test "without title should not be saved" do
-    note = Note.new(
-      title: nil,
-      body: "# Note without title",
-      user_id: @user.id
-    )
+  test "should save when title present, body empty" do
+    assert_difference "Note.count", 1 do
+      Note.create(
+        title: "Note1",
+        body: "",
+        user_id: @user.id
+      )
+    end
+  end
 
-    assert note.invalid?
+  test "should save when title empty, body present" do
+    assert_difference "Note.count", 1 do
+      Note.create(
+        title: "",
+        body: "# Note 1",
+        user_id: @user.id
+      )
+    end
+  end
+
+  test "should not save when title and body both empty" do
+    assert_difference "Note.count", 0 do
+      Note.create(
+        title: "",
+        body: "",
+        user_id: @user.id
+      )
+    end
+  end
+
+  test "should set default title when title empty" do
+    note = Note.create(
+            title: "",
+            body: "# Note 1",
+            user_id: @user.id
+          )
+
+    assert_equal "no title", note.title
   end
 
   test "title exceeding 255 chararcters should not be saved" do


### PR DESCRIPTION
## 概要
Noteモデルのバリデーションの仕様変更を行いました。

## 作業内容
- バリデーションの変更
  - title, bodyが空の場合はエラー
  - bodyのみある場合はデフォルトのtitleをセット
- モデルテストの修正

## 動作確認
### title, bodyが空の場合はバリデーションエラーになる
```
annotation-guidelines(dev)> Note.create!(title: "", body: "", user_id: 1)
  TRANSACTION (0.0ms)  BEGIN immediate TRANSACTION /*application='AnnotationGuidelines'*/
  User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='AnnotationGuidelines'*/
  TRANSACTION (0.0ms)  ROLLBACK TRANSACTION /*application='AnnotationGuidelines'*/
(annotation-guidelines):1:in '<main>': Validation failed: Title and body cannot both be empty. (ActiveRecord::RecordInvalid)
```

### titleが空の場合にデフォルトのtitleがセットされる
```
annotation-guidelines(dev)> Note.create!(title: "", body: "abc", user_id: 1)
  TRANSACTION (0.2ms)  BEGIN immediate TRANSACTION /*application='AnnotationGuidelines'*/
  User Load (0.9ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='AnnotationGuidelines'*/
  Note Create (0.4ms)  INSERT INTO "notes" ("title", "body", "user_id", "created_at", "updated_at") VALUES ('no title', 'abc', 1, '2025-02-19 05:25:05.749427', '2025-02-19 05:25:05.749427') RETURNING "id" /*application='AnnotationGuidelines'*/
  TRANSACTION (0.8ms)  COMMIT TRANSACTION /*application='AnnotationGuidelines'*/
=> #<Note:0x000000012334a3e0 id: 31, title: "no title", body: "abc", user_id: 1, created_at: "2025-02-19 05:25:05.749427000 +0000", updated_at: "2025-02-19 05:25:05.749427000 +0000">
```