### PR TITLE
Add user authentication

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -21,14 +21,24 @@ body {
 }
 
 header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   background-color: #4CAF50;
   padding: 20px;
 
   a {
     color: white;
+    text-decoration: none;
+  }
+
+  .logo a {
     font-weight: bold;
     font-size: 24px;
-    text-decoration: none;
+  }
+
+  .account-menu {
+    margin-right: 40px;
   }
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-
-  private
-
-  # Set current_user until make login function.
-  def current_user
-    @current_user ||= User.first
-  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,4 +1,5 @@
 class NotesController < ApplicationController
+  before_action :authenticate_user!, except: %i[index show]
   before_action :set_note, only: %i[edit update destroy]
 
   def index

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%#= render "devise/shared/links" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,3 +1,13 @@
 <header>
-  <%= link_to "Annotation Guideline DB", root_path %>
+  <div class="logo">
+    <%= link_to "Annotation Guideline DB", root_path %>
+  </div>
+  <div class="account-menu">
+    <% if user_signed_in? %>
+      <%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }  %>
+    <% else %>
+      <%= link_to "Login", new_user_session_path %>
+    <% end %>
+    </ul>
+  </div>
 </header>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -4,6 +4,9 @@
   <%= @note.html_body %>
 </div>
 
-<%= link_to 'Edit', edit_note_path(@note) %>
-<%= link_to 'Delete', @note, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+<% if current_user == @note.user %>
+  <%= link_to 'Edit', edit_note_path(@note) %>
+  <%= link_to 'Delete', @note, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+<% end %>
+
 <%= link_to 'Back', :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   root "notes#index"
 
   resources :notes
+  devise_for :users
 end


### PR DESCRIPTION
Closes: #10

## 概要
ユーザー認証機能を追加しました。

## 作業内容
- ログイン/ログアウト機能の追加
- Noteのリソースを編集するページ、操作にはログインを必須化
- Note編集/削除ボタンはリソースオーナーのみ表示するように変更
- ログイン状態に合わせてヘッダーにLogin/Logoutリンクを設置
- 仮で設定していたcurrent_userメソッドを削除

## 動作確認
### ログイン
|<img width="1434" alt="image" src="https://github.com/user-attachments/assets/31efa15b-2d54-44ed-b2aa-91583ebae483" />|
|:-|

|<img width="1434" alt="image" src="https://github.com/user-attachments/assets/93973289-d166-4844-8819-34eba5912bf5" />|
|:-|

### ログアウト
|<img width="1423" alt="image" src="https://github.com/user-attachments/assets/7d407242-2846-4cb1-9cd3-8c4f0d73895c" />|
|:-|

### ログインしていない状態でリソースを変更するページには遷移できない

https://github.com/user-attachments/assets/9e78207f-0680-48e9-b821-7a13630e9075

### リソースオーナーがログイン状態でのみnote編集/削除ボタンが表示される
|<img width="1424" alt="image" src="https://github.com/user-attachments/assets/04605f76-18d2-456e-a965-c6723f5fc1d4" />|
|:-|

|<img width="1411" alt="image" src="https://github.com/user-attachments/assets/e1442884-f25f-431f-8633-77d307044cb7" />|
|:-|