### PR TITLE
Add user registration

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -39,6 +39,16 @@ header {
 
   .account-menu {
     margin-right: 40px;
+
+    ul {
+      margin: 0;
+      display: flex;
+      list-style: none;
+
+      li {
+        margin: 0px 10px;
+      }
+    }
   }
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable
 
   has_many :notes, dependent: :destroy
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,4 +23,4 @@
   </div>
 <% end %>
 
-<%#= render "devise/shared/links" %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,11 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,11 +3,14 @@
     <%= link_to "Annotation Guideline DB", root_path %>
   </div>
   <div class="account-menu">
-    <% if user_signed_in? %>
-      <%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }  %>
-    <% else %>
-      <%= link_to "Login", new_user_session_path %>
-    <% end %>
+    <ul>
+      <% if user_signed_in? %>
+        <li><%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }  %></li>
+      <% else %>
+        <li><%= link_to "Sign up", new_user_registration_path %></li>
+        <li><%= link_to "Login", new_user_session_path %></li>
+      <% end %>
+    </ul>
     </ul>
   </div>
 </header>

--- a/db/migrate/20250219081448_add_confirmable_to_users.rb
+++ b/db/migrate/20250219081448_add_confirmable_to_users.rb
@@ -1,0 +1,10 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_070033) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_19_081448) do
   create_table "notes", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
@@ -29,6 +29,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_070033) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-user = User.create!(email: 'user1@example.com', password: 'password')
+user = User.create!(email: 'user1@example.com', password: 'password', confirmed_at: Time.now)
 
 30.times do |i|
   Note.create!(

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,3 +8,4 @@ one:
   id: 1
   email: test1@example.com
   encrypted_password: password
+  confirmed_at: <%= Time.now %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,19 +3,19 @@ require "test_helper"
 class UserTest < ActiveSupport::TestCase
   test "valid user should be saved" do
     assert_difference "User.count", 1 do
-      User.create(email: "valid@example.com", password: "password")
+      User.create(email: "valid@example.com", password: "password", confirmed_at: Time.now)
     end
   end
 
   test "invalid email user should not saved" do
     assert_no_difference "User.count" do
-      User.create(email: "invalid_email", password: "password")
+      User.create(email: "invalid_email", password: "password", confirmed_at: Time.now)
     end
   end
 
   test "invalid password user should not saved" do
     assert_no_difference "User.count" do
-      User.create(email: "valid2@example.com", password: "short")
+      User.create(email: "valid2@example.com", password: "short", confirmed_at: Time.now)
     end
   end
 end


### PR DESCRIPTION
Closes: #11

## 概要
User登録機能を追加しました。

## 作業内容
- devise confirmableの有効化
- ユーザー登録、confirmationメール再送信ページの追加
- ヘッダー、ログインページにユーザー登録ページへのリンクを追加
- confirmable追加に合わせてテスト、seedの修正

## 動作確認
### 新規作成ページ
|<img width="1422" alt="image" src="https://github.com/user-attachments/assets/d2f3a907-a270-400f-bcb6-1f215db2310a" />|
|:-|

### 登録後
|<img width="1428" alt="image" src="https://github.com/user-attachments/assets/7bce9cf0-8145-4638-9bca-1763fe215dc0" />|
|:-|

### メールが送られている
|<img width="700" alt="image" src="https://github.com/user-attachments/assets/4de67b7e-3818-4d27-add8-4410930c14cb" />|
|:-|

### confirm後
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/3f290b70-eda5-49a1-9366-a20719098766" />|
|:-|

### 再送信ページ
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/3d9f8feb-0de3-49cc-aff3-2ed061d6b61a" />|
|:-|

### 再送信ができる
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/4f40f41c-000d-4cb4-a589-301f75da9214" />|
|:-|