### PR TITLE
Add user page and user edit function

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find_by!(email: params[:email])
+    @notes = @user.notes.order(updated_at: :desc).page(params[:page])
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,39 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<%= link_to "Back", :back %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,6 +5,7 @@
   <div class="account-menu">
     <ul>
       <% if user_signed_in? %>
+        <li><%= link_to current_user.email, user_path(current_user.email) %></li>
         <li><%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }  %></li>
       <% else %>
         <li><%= link_to "Sign up", new_user_registration_path %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,9 @@
-<h1><%= @user.email %></h1>
+<section>
+  <h1><%= @user.email %></h1>
+  <% if current_user == @user %>
+    <%= link_to "Edit", edit_user_registration_path %>
+  <% end %>
+</section>
 
 <section>
   <h2>Notes</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,29 @@
+<h1><%= @user.email %></h1>
+
+<section>
+  <h2>Notes</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Content</th>
+        <th>Updated at</th>
+        <th>Author</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @user.notes.each do |note| %>
+        <tr>
+          <td><%= link_to note.title, note_path(note) %></td>
+          <td class="note-body"><%= note.body %></td>
+          <td><%= note.updated_at %></td>
+          <td><%= note.user.email %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @notes %>
+</section>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
 
   resources :notes
   devise_for :users
+  get "/users/:email" => "users#show", :constraints => { email: /.+@.+\..*/ }, as: "user"
 end


### PR DESCRIPTION
Closes: #12 

## 概要
User詳細ページ、編集機能の追加を行いました。

## 作業内容
- user詳細ページのリンクとして、ログイン時にヘッダーにemailを表示
- User詳細ページの作成
  - userが持つnoteの一覧表示
- User編集ページの追加

## 動作確認
### User詳細ページ
ヘッダーのemailから遷移できるようにしました。
パスは`/users/:email`としました。
|<img width="1431" alt="image" src="https://github.com/user-attachments/assets/8aa859c4-4467-4696-b69f-75aa3c264127" />|
|:-|

### User編集ページ
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/acb8ffcc-aae8-4698-9c3c-e078d63d37db" />|
|:-|

変更の動作も問題ないです。
|<img width="1437" alt="image" src="https://github.com/user-attachments/assets/f7c23ed6-7d43-4a18-a9ad-9431ac6c6f99" />|
|:-|