### PR TITLE
Add feature to reset password and delete account

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,3 +37,11 @@
 <% end %>
 
 <%= link_to "Back", :back %>
+
+<%= link_to "delete account",
+            registration_path(resource_name),
+            data: {
+              turbo_confirm: "Be careful! All the data that belong to you will be deleted.",
+              turbo_method: :delete
+              }
+%>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -6,6 +6,10 @@
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end %>
 
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
 <% end %>


### PR DESCRIPTION
Closes: #13 

## 概要
アカウント削除、パスワード再設定機能を追加しました。

## 作業内容
- アカウント削除機能の追加
- パスワード再設定機能の追加

## 動作確認
### アカウント削除
#### 削除時
|<img width="1000" alt="image" src="https://github.com/user-attachments/assets/8dab7748-e19c-491b-ad23-51c3a5fd52ee" />|
|:-|

#### 削除後
|<img width="1000" alt="image" src="https://github.com/user-attachments/assets/3fdf27da-f0c9-4f38-a236-0a62851265da" />|
|:-|

#### ログ
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/2cac9de4-1382-4e12-a55d-501b5be067a7" />


### パスワード再設定機能

https://github.com/user-attachments/assets/8d8aa8f5-b29f-4d60-a217-9e7ea2a2c12d
