### PR TITLE
Use rem instead of px on font-size

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,7 +23,7 @@ body {
   padding: 0;
   margin-bottom: 90px;
   color: #555555;
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 header {
@@ -40,7 +40,7 @@ header {
 
   .logo a {
     font-weight: bold;
-    font-size: 28px;
+    font-size: 1.75rem;
   }
 
   .account-menu {
@@ -62,7 +62,7 @@ header {
   border-bottom: 2px solid #4CAF50;
 
   .page-title {
-    font-size: 26px;
+    font-size: 1.625rem;
     font-weight: bold;
     padding: 0 5px;
   }
@@ -88,7 +88,7 @@ header {
     border: 1px solid lightgray;
     border-radius: 8px;
     padding: 6px 10px;
-    font-size: 16px;
+    font-size: 1rem;
     text-align: center;
     cursor: pointer;
   }
@@ -114,7 +114,7 @@ header {
     border: 1px solid lightgray;
     border-radius: 8px;
     padding: 6px 10px;
-    font-size: 16px;
+    font-size: 1rem;
     text-align: center;
   }
 }

--- a/app/assets/stylesheets/notes.css
+++ b/app/assets/stylesheets/notes.css
@@ -75,7 +75,7 @@
   label {
     display: block;
     color: #666666;
-    font-size: 20px;
+    font-size: 1.25rem;
     font-weight: bold;
   }
 
@@ -87,7 +87,7 @@
     width: 100%;
     box-sizing: border-box;
     height: 30px;
-    font-size: 20px;
+    font-size: 1.25rem;
     border: 1px solid #CED4D9;
     border-radius: 4px;
     padding-left: 6px;
@@ -100,11 +100,11 @@
   }
 
   .EasyMDEContainer .CodeMirror {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 
   .EasyMDEContainer .editor-preview {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 }
 

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -7,7 +7,7 @@
     label {
       display: block;
       color: #666666;
-      font-size: 20px;
+      font-size: 1.25rem;
       font-weight: bold;
     }
 
@@ -15,7 +15,7 @@
       width: 300px;
       box-sizing: border-box;
       height: 30px;
-      font-size: 16px;
+      font-size: 1rem;
       border: 1px solid #CED4D9;
       border-radius: 4px;
       padding-left: 6px;
@@ -38,7 +38,7 @@
   border-left: 4px solid #4CAF50;
 
   .semi-title {
-    font-size: 24px;
+    font-size: 1.5rem;
     font-weight: bold;
     padding: 0 5px;
   }


### PR DESCRIPTION
## 概要
CSSのfont-sizeの指定をpxからremに変更しました。

## 作業内容
- 各CSSファイルのfont-sizeをremに変更

## 画面確認
全体的に変換による相違は無さそうでした。

|<img width="1416" alt="image" src="https://github.com/user-attachments/assets/f2bfe2b7-d041-430c-9bbb-5e1857578003" />|
|:-|

|<img width="1405" alt="image" src="https://github.com/user-attachments/assets/02897bf5-629c-46b4-9443-f7fef6a640b8" />|
|:-|

|<img width="1377" alt="image" src="https://github.com/user-attachments/assets/c778ef19-759d-48a9-ac6f-f4eab8b7d811" />|
|:-|