### PR TITLE
Change application name to NearNote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # check=error=true
 
 # This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
-# docker build -t annotation_guidelines .
-# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name annotation_guidelines annotation_guidelines
+# docker build -t near_note .
+# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name near_note near_note
 
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Enter the required information.
 
 label example:
 ```
-annotation-guidelines
+near-note
 ```
 
 reCAPTCHA type:

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <div class="logo">
-    <%= link_to "Annotation Guideline DB", root_path %>
+    <%= link_to "NearNote", root_path %>
   </div>
   <div class="account-menu">
     <ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Annotation Guidelines" %></title>
+    <title><%= content_for(:title) || "NearNote" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "AnnotationGuidelines",
+  "name": "NearNote",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "AnnotationGuidelines.",
+  "description": "NearNote.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module AnnotationGuidelines
+module NearNote
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0


### PR DESCRIPTION
## 概要
アプリ名をNearNoteに変更しました。

## 作業内容
- ブラウザタイトルを変更
- ヘッダーのアプリ名を変更
- その他ディレクトリ内の旧アプリ名を使っている箇所の変更

## 作業後のソースコード検索
seedsとmigrationファイルのみが`annotation`に引っ掛かる状態になりました。
seedsは内容的に問題なさそうなのでそのままにしています。

|<img width="554" alt="image" src="https://github.com/user-attachments/assets/b658a053-d89e-4e60-8900-f5f874661970" />|
|:-|

## 作業後のブラウザタイトル、ヘッダー
|<img width="789" alt="image" src="https://github.com/user-attachments/assets/ed730608-110e-4d42-8fcd-3866ae043515" />|
|:-|
