### PR TITLE
Revise button style

### DIFF
--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,14 +1,3 @@
-.button-bottom-left {
-  position: fixed;
-  bottom: 80px;
-}
-
-.button-bottom-right {
-  position: fixed;
-  bottom: 80px;
-  right: 120px;
-}
-
 .user-form {
   margin-bottom: 10px;
 
@@ -87,4 +76,10 @@
 
 .delete-token {
   color: #555555;
+}
+
+.user-links {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 60px;
 }

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -21,4 +21,6 @@
   <% end %>
 </div>
 
-<%= link_to "Back", :back, class: "button button-bottom-left" %>
+<div class="user-links">
+  <%= link_to "Back", :back, class: "button" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -26,4 +26,6 @@
   <% end %>
 </div>
 
-<%= link_to "Back", :back, class: "button button-bottom-left" %>
+<div class="user-links">
+  <%= link_to "Back", :back, class: "button" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,13 +40,16 @@
   <% end %>
 </div>
 
-<%= link_to "Back", :back, class: "button button-bottom-left" %>
+<div class="user-links">
+  <%= link_to "Back", :back, class: "button" %>
 
-<%= link_to "Delete account",
-            registration_path(resource_name),
-            data: {
-              turbo_confirm: "Be careful! All the data that belong to you will be deleted.",
-              turbo_method: :delete
-              },
-            class: "button-red button-bottom-right"
-%>
+  <%= link_to "Delete account",
+              registration_path(resource_name),
+              data: {
+                turbo_confirm: "Be careful! All the data that belong to you will be deleted.",
+                turbo_method: :delete
+                },
+              class: "button-red"
+  %>
+</div>
+


### PR DESCRIPTION
## 概要
User関連ページのback等のボタンはposition: fixedを使って常に画面左下に表示していました。
バリデーションエラー等で画面下まで上の要素が来た時に重なってしまう問題がありました。
back等のボタンは画面下固定ではなく上の要素から余白を十分開けた下に配置するように変更しました。

## 作業内容
- 以下のページ遷移用のボタンのスタイルを変更
  - ユーザー編集ページ
  - Confirmationメール再送信ページ
  - Password再設定ページ

## 修正内容の確認
### ユーザー編集ページ
#### before
|<img width="1503" alt="image" src="https://github.com/user-attachments/assets/41815e70-52ab-44d0-8cef-a06408f66958" />|
|:-|

#### after
|<img width="1786" alt="image" src="https://github.com/user-attachments/assets/6d8aae91-c0e7-4197-b290-529b1e7e551c" />|
|:-|

### Confirmationメール再送信ページ
#### before
|<img width="1291" alt="image" src="https://github.com/user-attachments/assets/2796e77b-f66e-41a4-bbab-b27a772949f1" />|
|:-|

#### after
|<img width="1288" alt="image" src="https://github.com/user-attachments/assets/6ab45a69-4d5e-41e3-bf44-2ff5a166bacf" />|
|:-|

### Password再設定ページ
#### before
|<img width="1291" alt="image" src="https://github.com/user-attachments/assets/600ceddc-89fa-416c-b6a2-5fbd35918142" />|
|:-|

#### after
|<img width="1255" alt="image" src="https://github.com/user-attachments/assets/0804975b-1ba4-409f-8781-da94e1998391" />|
|:-|