### PR TITLE
Revise back button path

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -22,5 +22,5 @@
 </div>
 
 <div class="user-links">
-  <%= link_to "Back", :back, class: "button" %>
+  <%= link_to "Back", new_user_registration_path, class: "button" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <div class="user-links">
-  <%= link_to "Back", new_user_password_path, class: "button" %>
+  <%= link_to "Back", new_user_session_path, class: "button" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <div class="user-links">
-  <%= link_to "Back", :back, class: "button" %>
+  <%= link_to "Back", new_user_password_path, class: "button" %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -41,7 +41,7 @@
 </div>
 
 <div class="user-links">
-  <%= link_to "Back", :back, class: "button" %>
+  <%= link_to "Back", user_path(current_user.email), class: "button" %>
 
   <%= link_to "Delete account",
               registration_path(resource_name),


### PR DESCRIPTION
## 概要
backボタンは遷移前のURLになるようにしている箇所がありました。
バリデーションエラーが発生した後にbackボタンを押すと同じページ遷移してしまう問題がありました。

この問題を解決するために、backボタンでは「現ページに遷移できるリンクが配置してある元のページ」に遷移するように変更しました。

## 作業内容
- User編集ページのbackボタンでUser詳細ページに遷移するように変更
- Confirmationメール再送信ページでSign upページに遷移するように変更
- Password再設定ページでLog inページに遷移するように変更