### PR TITLE
Return 403 with alert when try to edit other users note

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
-  before_action :set_note, only: %i[edit update destroy]
+  before_action :set_note, only: %i[update destroy]
 
   def index
     @note_search_form = NoteSearchForm.new(search_params)
@@ -30,7 +30,14 @@ class NotesController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+    @note = Note.find_by!(uuid: params[:id])
+
+    unless @note.user == current_user
+      flash.now[:alert] = "You do not have permission to edit this note."
+      render template: "notes/show", status: :forbidden
+    end
+  end
 
   def update
     if @note.update(note_params)


### PR DESCRIPTION
## 概要
他ユーザーのNote編集ページにリクエストすると403レスポンスとともにalertが表示するように変更しました。

## 動作確認
### 変更前
以下の画面とともに404エラーが起こります。
production環境であればpublic/404.htmlがレンダリングされると思います。
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/38957227-3004-4009-8b01-c85400bb6c93" />

### 変更後
alertが出るように変更しました。
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/a4ce412e-0485-47f5-a51f-e6c8cdb0a48d" />

HTTPレスポンスは403 forbiddenとなるようにしました。
|<img width="1629" alt="image" src="https://github.com/user-attachments/assets/5288ce06-56d7-4e8a-a427-750d945243f9" />|
|:-|